### PR TITLE
Separate sudo from build, use jobs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,7 +23,7 @@ cd grub
 patch -p1 < 0001-grub-core-normal-main.c-Display-FREE-AS-IN-FREEDOM-n.patch
 ./bootstrap
 ./configure --with-platform=coreboot
-make
+make -j`nproc`
 sudo make install
 
 ##Generate grub elf
@@ -45,17 +45,20 @@ cp 'libreboot-x200-configs-release1/gbe-ich9m.set' util/bincfg
 
 ##Compile utilities
 cd util/cbfstool
+make -j`nproc`
 sudo make install
 
 cd ../nvramtool
+make -j`nproc`
 sudo make install
 
 cd ../ifdtool
+make -j`nproc`
 sudo make install
 
 ##Generate descriptor and gbe rom
 cd ../bincfg
-make
+make -j`nproc`
 make gen-ifd-x200
 make gen-gbe-ich9m
 mkdir -p ../../3rdparty/blobs/mainboard/lenovo/x200
@@ -65,7 +68,7 @@ cp flashregion_3_gbe.bin ../../3rdparty/blobs/mainboard/lenovo/x200/gbe.bin
 ## Compile Coreboot
 cd ../..
 make crossgcc-i386 CPUS=$(nproc)
-make
+make -j`nproc`
 
 ## Add files to rom
 cp build/coreboot.rom x200.rom


### PR DESCRIPTION
Hi there,

Thanks for your work! Here are some small tweaks to the build script: 

- use `sudo` only for `make install` and use plain `make` elsewhere so that permissions & ownership on the generated files are correct
- use the `-j` flags for parallel build jobs to speed things up -- this rather helped building this on my x200